### PR TITLE
Fix order options get assigned in.

### DIFF
--- a/lib/tinyid.js
+++ b/lib/tinyid.js
@@ -19,7 +19,7 @@ function Generator(options) {
 			wheel: options
 		};
 	}
-	_.assign(this, options, Generator.defaults);
+	_.assign(this, Generator.defaults, options);
 	this.alphabet = Generator.wheelToAlphabet(this.wheel);
 }
 


### PR DESCRIPTION
So defaults don't actually override options.
